### PR TITLE
allow redis to be configured with sentinels

### DIFF
--- a/bin/pushr
+++ b/bin/pushr
@@ -21,6 +21,10 @@ ARGV.options do |opts|
     Pushr::Core.configuration_file = file
   end
 
+  opts.on('-j JSON', '--json JSON', 'Read the configuration from this JSON') do |json|
+    Pushr::Core.configuration_json = json
+  end
+
   opts.on('-o HOST', '--redis-host HOST', String, 'Hostname of redis instance') do |host|
     connection[:host] = host
   end

--- a/lib/pushr/configuration.rb
+++ b/lib/pushr/configuration.rb
@@ -49,8 +49,10 @@ module Pushr
       MultiJson.dump(to_hash)
     end
 
-    def self.all
-      if Pushr::Core.configuration_file # only set if file exists
+    def self.apps
+      if Pushr::Core.configuration_json # only set if file exists
+        read_from_json
+      elsif Pushr::Core.configuration_file # only set if file exists
         read_from_yaml_file
       else
         read_from_redis
@@ -60,6 +62,11 @@ module Pushr
     def self.find(key)
       config = Pushr::Core.redis { |conn| conn.hget('pushr:configurations', key) }
       instantiate_json(config, key)
+    end
+
+    def self.read_from_json
+      configs = ::MultiJson.load Pushr::Core.configuration_json
+      configs['apps'].map { |hsh| instantiate(hsh) }
     end
 
     def self.read_from_yaml_file

--- a/lib/pushr/core.rb
+++ b/lib/pushr/core.rb
@@ -31,7 +31,7 @@ module Pushr
 
     def self.redis(&block)
       fail ArgumentError, 'requires a block' unless block
-      @redis ||= Pushr::RedisConnection.create
+      @redis ||= RedisConnection.create
       @redis.with(&block)
     end
 
@@ -52,6 +52,14 @@ module Pushr
 
     def self.external_id_tag
       options[:external_id_tag]
+    end
+
+    def self.configuration_json
+      options[:configuration_json]
+    end
+
+    def self.configuration_json=(json)
+      options[:configuration_json] = json
     end
 
     def self.configuration_file

--- a/lib/pushr/daemon.rb
+++ b/lib/pushr/daemon.rb
@@ -45,7 +45,11 @@ module Pushr
       # feedback handler + app + app.totalconnections
       connections = 1 + 1 + App.total_connections
       Pushr::Core.configure do |config|
-        config.redis = { size: connections }
+        config.redis =  if Pushr::Core.configuration_json
+          ::MultiJson.load(Pushr::Core.configuration_json, :symbolize_keys => true)[:redis]
+        else
+          { size: connections }
+        end
       end
     end
 

--- a/lib/pushr/daemon/app.rb
+++ b/lib/pushr/daemon/app.rb
@@ -7,7 +7,7 @@ module Pushr
         attr_reader :apps
 
         def load
-          @apps = Pushr::Configuration.all.keep_if { |c| c.enabled == true }.map { |c| App.new(c) }
+          @apps = Pushr::Configuration.apps.keep_if { |c| c.enabled == true }.map { |c| App.new(c) }
         end
 
         def total_connections

--- a/lib/pushr/redis_connection.rb
+++ b/lib/pushr/redis_connection.rb
@@ -5,33 +5,22 @@ require 'redis/namespace'
 module Pushr
   class RedisConnection
     def self.create(options = {})
-      url = options[:url] || determine_redis_provider || 'redis://localhost:6379/0'
-      driver = options[:driver] || 'ruby'
-      # need a connection for Fetcher and Retry
-      size = options[:size] || 5
       namespace = options[:namespace] || Pushr::Core.options[:namespace]
 
-      ConnectionPool.new(timeout: 1, size: size) do
-        build_client(url, namespace, driver)
-      end
-    end
+      config = {
+        url: options[:url] || 'redis://master',
+        sentinels: options[:sentinels] || [],
+      }
 
-    def self.build_client(url, namespace, driver)
-      client = Redis.connect(url: url, driver: driver)
-      if namespace
-        Redis::Namespace.new(namespace, redis: client)
-      else
-        client
-      end
-    end
-    private_class_method :build_client
+      ConnectionPool.new(timeout: options[:timeout] || 1, size: options[:size] || 5) do
+        client = Redis.connect(config)
 
-    # Not public
-    def self.determine_redis_provider
-      return ENV['PUSHR_URL'] if ENV['PUSHR_URL']
-      return ENV['REDISTOGO_URL'] if ENV['REDISTOGO_URL']
-      provider = ENV['REDIS_PROVIDER'] || 'REDIS_URL'
-      ENV[provider]
+        if namespace
+          Redis::Namespace.new(namespace, redis: client)
+        else
+          client
+        end
+      end
     end
   end
 end

--- a/lib/pushr/version.rb
+++ b/lib/pushr/version.rb
@@ -1,3 +1,3 @@
 module Pushr
-  VERSION = '1.0.2'
+  VERSION = '1.1.0'
 end

--- a/pushr-core.gemspec
+++ b/pushr-core.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 1.9.3'
 
-  s.add_runtime_dependency 'redis', '~> 3.0'
+  s.add_runtime_dependency 'redis', '~> 3.2.1'
   s.add_runtime_dependency 'redis-namespace', '~> 1.4'
   s.add_runtime_dependency 'multi_json'
   s.add_runtime_dependency 'connection_pool', '~> 2.0'

--- a/spec/lib/pushr/configuration_spec.rb
+++ b/spec/lib/pushr/configuration_spec.rb
@@ -10,7 +10,7 @@ describe Pushr::Configuration do
 
   describe 'all' do
     it 'returns all configurations' do
-      expect(Pushr::Configuration.all).to eql([])
+      expect(Pushr::Configuration.apps).to eql([])
     end
   end
 
@@ -34,7 +34,7 @@ describe Pushr::Configuration do
 
     it 'should save a configuration' do
       config.save
-      expect(Pushr::Configuration.all.count).to eql(1)
+      expect(Pushr::Configuration.apps.count).to eql(1)
     end
   end
 
@@ -83,9 +83,9 @@ describe Pushr::Configuration do
     let!(:config) { Pushr::ConfigurationDummy.new(app: 'app_name', connections: 2, enabled: true) }
     it 'should remove a configuration' do
       config.save
-      expect(Pushr::Configuration.all.count).to eql(1)
+      expect(Pushr::Configuration.apps.count).to eql(1)
       config.delete
-      expect(Pushr::Configuration.all.count).to eql(0)
+      expect(Pushr::Configuration.apps.count).to eql(0)
     end
   end
 end


### PR DESCRIPTION
- add a -j config option to the daemon to configure with a json blob (for both redis and the apps list)
- add sentinels config to redis
